### PR TITLE
ManyToOneConcurrentArrayQueueMailboxActorTest gave false positive due to config error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build/
 *.ipr
 .gradle/
 out/
+.java-version

--- a/src/main/java/io/vlingo/xoom/actors/Actor.java
+++ b/src/main/java/io/vlingo/xoom/actors/Actor.java
@@ -26,6 +26,10 @@ public abstract class Actor implements Startable, Stoppable, Relocatable, TestSt
   final ResultReturns returns;
   final LifeCycle lifeCycle;
 
+  // hack to run test
+  public Class getMailboxClass() {
+    return lifeCycle.environment.mailbox.getClass();
+  }
   /**
    * Answers the {@code address} of this {@code Actor}.
    * @return Address


### PR DESCRIPTION
* Related to issue#100 - actor can check what mailbox type it is being served by
* Test setup code is fixed; ManyToOneConcurrentArrayQueuePlugin is now started as expected
* New test introduced to validate the mailbox type for the actor
* Actor base class exposes method to tell what mailbox class is being used by the actor